### PR TITLE
Changed default configuration MISR of TopicConfig

### DIFF
--- a/src/main/java/net/mguenther/kafka/junit/TopicConfig.java
+++ b/src/main/java/net/mguenther/kafka/junit/TopicConfig.java
@@ -57,7 +57,7 @@ public class TopicConfig {
         public TopicConfig build() {
             ifNonExisting("cleanup.policy", "delete");
             ifNonExisting("delete.retention.ms", "86400000");
-            ifNonExisting("min.insync.replicas", "2");
+            ifNonExisting("min.insync.replicas", "1");
             return new TopicConfig(topic, numberOfPartitions, numberOfReplicas, properties);
         }
     }

--- a/src/test/java/net/mguenther/kafka/junit/TopicConfigTest.java
+++ b/src/test/java/net/mguenther/kafka/junit/TopicConfigTest.java
@@ -25,7 +25,7 @@ public class TopicConfigTest {
         assertThat(topicConfig.getNumberOfReplicas()).isEqualTo(1);
         assertThat(topicConfig.getProperties().getProperty("cleanup.policy")).isEqualTo("delete");
         assertThat(topicConfig.getProperties().getProperty("delete.retention.ms")).isEqualTo("86400000");
-        assertThat(topicConfig.getProperties().getProperty("min.insync.replicas")).isEqualTo("2");
+        assertThat(topicConfig.getProperties().getProperty("min.insync.replicas")).isEqualTo("1");
     }
 
     @Test


### PR DESCRIPTION
**Fundamental change  :-)** 
The MISR default configuration was changed to "2" in the past, resulting in a non working default topic configuration in combination with the default embedded kafka cluster configuration which specifies only one broker. 