### PR TITLE
Fix examples for JUnit 5

### DIFF
--- a/src/main/asciidoc/chapters/introduction.adoc
+++ b/src/main/asciidoc/chapters/introduction.adoc
@@ -31,10 +31,36 @@ The same applies for `@ClassRule`.
 === What about JUnit 5?
 
 You can use Kafka for JUnit with JUnit 5 of course. However, with its rule-based implementations, Kafka for JUnit is currently tailored for ease of use with JUnit 4. It implements no JUnit Jupiter extension for JUnit 5. There is an issue for that (cf. link:https://github.com/mguenther/kafka-junit/issues/4[ISSUE-004]), so the development wrt. a JUnit Jupiter extension is planned for a future release. PRs are welcome, though!
+As Junit 5 does not support rules, one approach is to start your cluster in a `@BeforeEach` method and it stop in an `@AfterEach` method. 
+
+```java
+public class JUnit5KafkaTest {
+
+    private EmbeddedKafkaCluster cluster;
+
+    @BeforeEach
+    public void setupKafka() {
+        cluster = provisionWith(useDefaults());
+        cluster.start();
+    }
+
+    @AfterEach
+    public void tearDownKafka() {
+        cluster.stop();
+    }
+
+    @Test
+    public void shouldWaitForRecordsToBePublished() throws Exception {
+        cluster.send(to("test-topic", "a", "b", "c").useDefaults());
+        cluster.observe(on("test-topic", 4).useDefaults());
+    }
+
+}
+```
 
 === Alternative ways
 
-You do not have to use the JUnit 4 rules if you are not comfortable with them or if you happen to use JUnit 5, which does not support rules any longer. `EmbeddedKafkaCluster` implements the `AutoCloseable` interface, so it is easy to manage it inside your tests yourself.
+You do not have to use the JUnit 4 rules if you are not comfortable with them. `EmbeddedKafkaCluster` implements the `AutoCloseable` interface, so it is easy to manage it inside your tests yourself.
 
 ```java
 public class KafkaTest {
@@ -43,6 +69,7 @@ public class KafkaTest {
   public void shouldWaitForRecordsToBePublished() throws Exception {
 
     try (EmbeddedKafkaCluster cluster = provisionWith(useDefaults())) {
+      cluster.start();
       cluster.send(to("test-topic", "a", "b", "c").useDefaults());
       cluster.observe(on("test-topic", 3).useDefaults());
     }


### PR DESCRIPTION
The try-with-resources example in the user guide was missing `cluster.start()`, so the test was getting NPEs.

I've also added a JUnit 5 example that uses `@BeforeEach` and `@AfterEach` methods to set up and tear down the cluster as this is my preferred approach. 