### PR TITLE
Update kafka to 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,13 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependencies -->
-        <kafka.version>2.4.0</kafka.version>
+        <kafka.version>2.5.0</kafka.version>
         <slf4j.version>1.7.25</slf4j.version>
         <lombok.version>1.18.0</lombok.version>
         <curator.version>4.0.1</curator.version>
         <junit.version>4.12</junit.version>
         <assertj.version>3.10.0</assertj.version>
-        <testcontainers.kafka.version>1.12.4</testcontainers.kafka.version>
+        <testcontainers.kafka.version>1.14.2</testcontainers.kafka.version>
         <!-- Asciidoctor dependencies -->
         <asciidoctor.version>1.5.4</asciidoctor.version>
         <asciidoctor-maven.version>1.5.3</asciidoctor-maven.version>
@@ -250,7 +250,7 @@
         <!-- Kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.13</artifactId>
             <version>${kafka.version}</version>
             <exclusions>
                 <exclusion>
@@ -261,7 +261,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
+            <artifactId>kafka_2.13</artifactId>
             <version>${kafka.version}</version>
             <classifier>test</classifier>
             <exclusions>


### PR DESCRIPTION
Kafka has released new version: 2.5

Unfortunately, it seems like `kafka_2.11` used in this project no longer receives updates so interoperability is not possible.
![image](https://user-images.githubusercontent.com/8916393/82450355-e37e9e80-9aac-11ea-8f93-d1f31cf0d452.png)

I prepared an update. 

Seems like tests pass and I have successfully used snapshot build in my project's tests(Spring Boot 2.3).