### PR TITLE
Bump version no of Apache Kafka to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependencies -->
-        <kafka.version>3.1.0</kafka.version>
+        <kafka.version>3.2.0</kafka.version>
         <slf4j.version>1.7.35</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <curator.version>5.1.0</curator.version>


### PR DESCRIPTION
Update version no of Apache Kafka from 3.1.0 to 3.2.0.

[Related issue 64](https://github.com/mguenther/kafka-junit/issues/64)

All tests green.