### PR TITLE
Issue #68: Scala 2.12 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.mguenther.kafka</groupId>
     <artifactId>kafka-junit</artifactId>
     <packaging>jar</packaging>
-    <version>3.3.0-SNAPSHOT</version>
+    <version>3.2.0-scala2.12</version>
     <name>Kafka for JUnit</name>
     <description>
         Provides an embedded Kafka cluster consisting of Apache ZooKeeper, Apache Kafka Brokers and Kafka Connect
@@ -261,7 +261,7 @@
         <!-- Kafka -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
+            <artifactId>kafka_2.12</artifactId>
             <version>${kafka.version}</version>
             <exclusions>
                 <exclusion>
@@ -272,7 +272,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
+            <artifactId>kafka_2.12</artifactId>
             <version>${kafka.version}</version>
             <classifier>test</classifier>
             <exclusions>


### PR DESCRIPTION
First, thank you for this great package @mguenther. It's a nice alternative where I cannot use `Testcontainers`.

Downgrading Kafka dependency from `2.13` to `2.12` in order to be used in environments where `Scala 2.13` is not available. 