### PR TITLE
Kafka 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Dependencies -->
-        <kafka.version>3.5.1</kafka.version>
+        <kafka.version>3.6.0</kafka.version>
         <slf4j.version>1.7.36</slf4j.version>
         <lombok.version>1.18.22</lombok.version>
         <curator.version>5.5.0</curator.version>


### PR DESCRIPTION
Upgrade kafka.version from 3.5.1 to 3.6.0.

The kafka-clients upgrade indirectly upgrades snappy-java from 1.1.10.1 to 1.1.10.4 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2023-43642